### PR TITLE
Validate that processing is parallel in c11_Batching#command_gateway. [solutions]

### DIFF
--- a/exercises/src/test/java/c11_Batching.java
+++ b/exercises/src/test/java/c11_Batching.java
@@ -56,8 +56,10 @@ public class c11_Batching extends BatchingBase {
                 );
 
         //do not change the code below
-        StepVerifier.create(processCommands)
-                    .verifyComplete();
+        Duration duration = StepVerifier.create(processCommands)
+                .verifyComplete();
+
+        Assertions.assertTrue(duration.getSeconds() <= 3, "Expected to complete in less than 3 seconds");
     }
 
 


### PR DESCRIPTION
Harden tests to make sure that aggregated groups are processed in parallel by asserting duration of the pipeline.

As suggested in https://github.com/schananas/practical-reactor/issues/2#issuecomment-1160151215
Merge alongside #4