### PR TITLE
Update CombiningPublishersBase.java

### DIFF
--- a/exercises/src/main/java/CombiningPublishersBase.java
+++ b/exercises/src/main/java/CombiningPublishersBase.java
@@ -50,7 +50,7 @@ public class CombiningPublishersBase {
     }
 
     public Flux<Integer> numberService1() {
-        return Flux.range(1, 3).doOnNext(System.out::println);
+        return Flux.range(1, 3).doOnNext(System.out::println).delaySubscription(Duration.ofMillis(100));
     }
 
     public Flux<Integer> numberService2() {


### PR DESCRIPTION
Test fails if `merge` is used instead of `concat`.