### PR TITLE
Update c2_TransformingSequence.java

### DIFF
--- a/exercises/src/test/java/c2_TransformingSequence.java
+++ b/exercises/src/test/java/c2_TransformingSequence.java
@@ -94,9 +94,9 @@ public class c2_TransformingSequence extends TransformingSequenceBase {
      */
     @Test
     public void sequence_sum() {
-        Mono<Integer> sum = null;
-        numerical_service()
-        //todo: do your changes here
+        Mono<Integer> sum = 
+            numerical_service()
+            //todo: do your changes here
         ;
 
         StepVerifier.create(sum)


### PR DESCRIPTION
The Mono initialization at  `null` can confuse.

We should expect this kind of completed test:
```java
    @Test
    public void sequence_sum() {
        Mono<Integer> sum = numerical_service()
                .reduce(0, Math::addExact);

        StepVerifier.create(sum)
                    .expectNext(55)
                    .verifyComplete();
    }
```