### PR TITLE
Update c7_unit_of_work exercise

### DIFF
--- a/exercises/src/test/java/c7_ErrorHandling.java
+++ b/exercises/src/test/java/c7_ErrorHandling.java
@@ -126,7 +126,7 @@ public class c7_ErrorHandling extends ErrorHandlingBase {
                 ;
 
         StepVerifier.create(taskFlux)
-                    .expectNextMatches(task -> task.executedExceptionally.get())
+                    .expectNextMatches(task -> task.executedExceptionally.get() && !task.executedSuccessfully.get())
                     .expectNextMatches(task -> task.executedSuccessfully.get())
                     .verifyComplete();
     }


### PR DESCRIPTION
First of all, Thank you for making this amazing repo. I'm trying to solve the exercises and I've been quite enjoying it. ❤️ 

I was trying to solve the `unit_of_work` exercise and I realized the test case can be improved. Since in my first attempt I wrote the following code:
```java
Flux<Task> taskFlux = taskQueue().flatMap(task ->
        task.execute()
                .onErrorResume(task::rollback)
                .then(task.commit())
                .thenReturn(task)
);
```

Which looks pretty and passes the tests. But, it both commits and rollbacks the failed task which is not logically correct. So, I made this PR to detect this case in the assertions.