### PR TITLE
doOnTerminate is not called when cancel is called

### DIFF
--- a/exercises/src/test/java/c4_LifecycleHooks.java
+++ b/exercises/src/test/java/c4_LifecycleHooks.java
@@ -154,7 +154,6 @@ public class c4_LifecycleHooks extends LifecycleHooksBase {
     /**
      * Add a side effect that increments `hooksTriggeredCounter` when the `temperatureFlux` terminates, either when
      * completing successfully, gets canceled or failing with an error.
-     * Use only one operator!
      */
     @Test
     public void one_to_catch_them_all() {


### PR DESCRIPTION
```
        Flux<Integer> temperatureFlux = room_temperature_service()
                .doOnTerminate(() -> System.out.println("onTerminate"))
                .doOnCancel(() -> System.out.println("onCancel"))
                .log();
```
with
```
      StepVerifier.create(temperatureFlux.take(0))
                    .expectNextCount(0)
                    .verifyComplete();
```
prints
```
[ INFO] (main) onSubscribe(FluxPeek.PeekSubscriber)
[ INFO] (main) cancel()
onCancel
```
The solution of using single operator of doOnTerminate is not going to work.